### PR TITLE
Fix alerts for healthcheck

### DIFF
--- a/ops/terraform/modules/kosa_monitoring/main.tf
+++ b/ops/terraform/modules/kosa_monitoring/main.tf
@@ -22,7 +22,7 @@ resource "aws_route53_health_check" "kosa_healthcheck" {
 
 
 resource "aws_cloudwatch_metric_alarm" "kosa_healthcheck_failed" {
-  alarm_name          = format("%s_healthcheck_failed", var.server_url)
+  alarm_name          = format("%s_healthcheck", var.server_url)
   namespace           = "AWS/Route53"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"


### PR DESCRIPTION
OK: "kosa-sandbox.pariyatti.app_healthcheck_failed" sounds ambiguous

Updated it to OK: "kosa-sandbox.pariyatti.app_healthcheck", dropping the failed
 
<img width="678" alt="Screen Shot 2022-07-02 at 6 43 08 PM" src="https://user-images.githubusercontent.com/4284516/177002371-8b42a7ad-575b-49d1-84a8-0dc8356d0c61.png">
