### PR TITLE
add the default 600 seconds wait_for_connection

### DIFF
--- a/ops/ansible/provision.yml
+++ b/ops/ansible/provision.yml
@@ -6,7 +6,7 @@
 
   tasks:
     - name: Wait for newly created system to become reachable
-      wait_for_connection:
+      ansible.builtin.wait_for_connection:
         timeout: 600
     - name: Add an Apt signing key for Caddy
       ansible.builtin.apt_key:

--- a/ops/ansible/provision.yml
+++ b/ops/ansible/provision.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: Wait for newly created system to become reachable
       wait_for_connection:
-      
+        timeout: 600
     - name: Add an Apt signing key for Caddy
       ansible.builtin.apt_key:
         url: https://dl.cloudsmith.io/public/caddy/stable/gpg.key

--- a/ops/ansible/provision.yml
+++ b/ops/ansible/provision.yml
@@ -5,6 +5,9 @@
     - vars.yml
 
   tasks:
+    - name: Wait for newly created system to become reachable
+      wait_for_connection:
+      
     - name: Add an Apt signing key for Caddy
       ansible.builtin.apt_key:
         url: https://dl.cloudsmith.io/public/caddy/stable/gpg.key


### PR DESCRIPTION
add the default 600 seconds wait_for_connection for new host dns propagation