### PR TITLE
Add more logs for cron file run and comment out bashrc line

### DIFF
--- a/ops/ansible/deploy.yml
+++ b/ops/ansible/deploy.yml
@@ -179,6 +179,13 @@
         line: "export DISCORD_WEBHOOK_URL={{ discord_backup_webhook_url }}"
       become: yes
 
+    - name: Comment out non-interactive return
+      lineinfile:
+        path: "/root/.bashrc"
+        search_string: '[ -z "$PS1" ] && return'
+        line: '#[ -z "$PS1" ] && return'
+      become: yes
+
     - name: Create a cron file for backup under /etc/cron.d
       ansible.builtin.cron:
         name: s3 backup
@@ -186,7 +193,7 @@
         minute: "0"
         hour: "12"
         user: root
-        job: "/srv/kosa-user/kosa/ops/scripts/backups/run.sh"
+        job: "/srv/kosa-user/kosa/ops/scripts/backups/run.sh > /var/log/kosa/kosa-cron.log 2>&1"
         cron_file: ansible_s3-backup
       become: yes
 


### PR DESCRIPTION
Add more logs for cron file run and comment out bashrc line that causes python script error of not being able to find the env variables.

For the last 3-4 weeks i have was checking for the backup notification on Wednesday to arrive on discord and they didn't arrive 😄 

```
    s3_bucket_name = os.environ["BACKUP_S3_BUCKET"]
  File "/usr/lib/python3.8/os.py", line 675, in __getitem__
    raise KeyError(key) from None
KeyError: 'BACKUP_S3_BUCKET'
```

The script was failing to find env variable because `[ -z "$PS1" ] && return` ensured the sourcing of bashrc didn't do anything. So fix was to comment it. In the process I found probably having the last cron job run log in the kosa logs directory can also help in troubleshooting issues related to s3 backups.

This Wednesday, the notifications did arrive, finally😀 
 
<img width="536" alt="Screen Shot 2022-07-16 at 4 32 29 PM" src="https://user-images.githubusercontent.com/4284516/179352212-1ed57e90-74a6-4c74-8d8b-b16031cc82bc.png">


So, changes are tested and verified to work!
