### PR TITLE
Add db-txt-trunc-prod to run before db-txt-prod

### DIFF
--- a/ops/ansible/db_txt_trunc.yml
+++ b/ops/ansible/db_txt_trunc.yml
@@ -1,0 +1,21 @@
+---
+- hosts: app
+  remote_user: "{{ user_acc }}"
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - name: stop kosa
+      systemd: name={{ app_name }} state=stopped
+      become: yes
+
+    - name: truncate db txt records in prod to repopulate records
+      tags: code
+      make:
+        chdir: "{{ app_dir }}"
+        target: "{{ seed_txt_trunc_target }}"
+      become: yes
+      become_user: "{{ user_acc }}"
+
+# There is an inherent assumption here that we would not want to re-run kosa until the txt
+# records have been repopulated. So, we choose to not restart the service as part of this execution.

--- a/ops/ansible/vars.yml
+++ b/ops/ansible/vars.yml
@@ -21,6 +21,7 @@ migrate_target: "db-migrate-prod"
 seed_txt_clean_target: "txt-clean"
 seed_txt_clone_target: "txt-clone"
 seed_txt_apply_target: "db-txt-prod"
+seed_txt_trunc_target: "db-txt-trunc-prod"
 update_txt_apply_target: "db-txt-prod"
 
 app_env_vars:


### PR DESCRIPTION
Tested in sandbox:

First taint the resource `terraform taint module.kosa-sandbox.null_resource.ansible_seed_data`

```
module.kosa-sandbox.null_resource.ansible_seed_data (local-exec): kosa-sandbox.pariyatti.app : ok=7    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

module.kosa-sandbox.null_resource.ansible_seed_data: Creation complete after 4m15s [id=4023695988790923148]

Apply complete! Resources: 3 added, 0 changed, 2 destroyed.
```

http://localhost:9999/_xtdb/query
`{:find [original-doha], :where [[e :doha/original-doha original-doha]]}` this count gives 181 including duplicates and 118[the one we expect] after removing duplicates. So, upon truncation is it expected for xtdb to have duplicates?