### PR TITLE
Add GitHub actions test for master branch

### DIFF
--- a/.github/workflows/kosa-tests.yml
+++ b/.github/workflows/kosa-tests.yml
@@ -41,5 +41,9 @@ jobs:
           # key: cljdeps-${{ hashFiles('project.clj') }}
           # key: cljdeps-${{ hashFiles('build.boot') }}
           restore-keys: cljdeps-
+      - name: create initial directories
+        run: make init-dirs
+      - name: install lein deps
+        run: make deps
       - name: run kosa tests
         run: make test

--- a/.github/workflows/kosa-tests.yml
+++ b/.github/workflows/kosa-tests.yml
@@ -1,0 +1,45 @@
+name: kosa backend tests
+
+on: [push]
+
+jobs:
+  kosa-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Prepare java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install leiningen
+        uses: DeLaGuardo/setup-clojure@10.1
+        with:
+          lein: 2.9.1
+
+      - name: Check leiningen version
+        run: lein version
+
+      - name: Cache clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn') }}
+          # key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          # key: cljdeps-${{ hashFiles('project.clj') }}
+          # key: cljdeps-${{ hashFiles('build.boot') }}
+          restore-keys: cljdeps-
+      - name: run kosa tests
+        run: make test

--- a/.github/workflows/kosa-tests.yml
+++ b/.github/workflows/kosa-tests.yml
@@ -1,6 +1,9 @@
 name: kosa backend tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   kosa-tests:

--- a/.github/workflows/kosa-tests.yml
+++ b/.github/workflows/kosa-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Install leiningen


### PR DESCRIPTION
Currently enabling only on master branch push activity. Tests are failing currently on latest master even in local, so github actions marks them as failed as well. Though the tests seem to be running in ubuntu 20.04 env without issues.