### PR TITLE
Update prod to Ubuntu 22.04

### DIFF
--- a/ops/scripts/restores/manual-restore.sh
+++ b/ops/scripts/restores/manual-restore.sh
@@ -29,8 +29,8 @@ chown -R "$USER:$USER" storage/
 # Stop the Kosa app service.
 systemctl stop "$APP_SERVICE"
 
-# Print the status of the Kosa app service.
-systemctl status "$APP_SERVICE"
+# Print the status of the Kosa app service. This causes the script to exit sooner
+# systemctl status "$APP_SERVICE"
 
 # Move current data to tmp backup and move the restored data directory to srv.
 mkdir -p "$LOCAL_BACKUP_DIR"

--- a/ops/terraform/modules/backup_s3_bucket/main.tf
+++ b/ops/terraform/modules/backup_s3_bucket/main.tf
@@ -30,3 +30,20 @@ resource "aws_s3_bucket_acl" "backup" {
   bucket = aws_s3_bucket.backup.id
   acl    = "private"
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "backup_lifecycle_configuration" {
+  rule {
+    id      = "delete_old_backups"
+    status  = "Enabled"
+
+    expiration {
+      days = 120
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 120
+    }
+  }
+
+  bucket = aws_s3_bucket.backup.id
+}

--- a/ops/terraform/production/main.tf
+++ b/ops/terraform/production/main.tf
@@ -5,6 +5,8 @@ module "kosa-production" {
   server_name = "kosa"
   ports       = [80, 443, 22]
 
+  server_blueprint_id = "ubuntu_22_04"
+
   # Manually set to 1 to update the txt files
   update_txt_files = 0
   server_tags = {


### PR DESCRIPTION
Update prod to Ubuntu 22.04 and restore recent backup from S3 to repopulate the data. Process verified on Sandbox and scripted.

Also add lifecycle configuration to backup bucket for keeping backups up to 120 days. This is to keep the size of s3 buckets finite and not ever growing.